### PR TITLE
Dialog title fix

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3,6 +3,7 @@
 
   "language": "Language",
   "choose_language": "Choose Language",
+  "choose_calendar_language": "Choose Calendar Language",
   "locale_en": "English",
   "locale_en_US": "English (US)",
   "locale_my": "Myanmar",

--- a/assets/translations/my.json
+++ b/assets/translations/my.json
@@ -3,6 +3,7 @@
 
   "language": "ဘာသာစကား",
   "choose_language": "ဘာသာစကားကို ရွေးပါ",
+  "choose_calendar_language": "ပြက္ခဒိန် ဘာသာစကားကို ရွေးပါ",
   "locale_en": "အင်္ဂလိပ်",
   "locale_en_US": "အင်္ဂလိပ် (US)",
   "locale_my": "မြန်မာ",

--- a/lib/src/widgets/settings/calendar_language_list_tile.dart
+++ b/lib/src/widgets/settings/calendar_language_list_tile.dart
@@ -1,7 +1,9 @@
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_mmcalendar/flutter_mmcalendar.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:iconly/iconly.dart';
+import 'package:mmcalendar/src/l10n/l10n.dart';
 import 'package:mmcalendar/src/shared/providers/mm_calendar_providers.dart';
 import 'package:mmcalendar/src/utils/shared_prefs/preference_manager.dart';
 
@@ -25,7 +27,7 @@ class CalendarLanguageListTile extends HookConsumerWidget {
       showAdaptiveDialog(
         context: context,
         builder: (context) => AlertDialog(
-          title: const Text('Theme'),
+          title: const Text(LocaleKeys.choose_calendar_language).tr(),
           content: SingleChildScrollView(
             child: Column(
               mainAxisSize: MainAxisSize.min,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mmcalendar
 description: "Simple myanmar calendar."
 publish_to: "none"
-version: 1.0.1+101
+version: 1.0.2+102
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
Fixed calendar language dialog title with:

- **en.json**

```json
{
  "choose_calendar_language": "Choose Calendar Language"
}
```
- **my.json**

```json
{
  "choose_calendar_language": "ပြက္ခဒိန် ဘာသာစကားကို ရွေးပါ"
}
```
